### PR TITLE
Use json_response in json_response example

### DIFF
--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -196,7 +196,7 @@ pub fn html_response(html: StringBuilder, status: Int) -> Response {
 /// 
 /// ```gleam
 /// let body = string_builder.from_string("{\"name\": \"Joe\"}")
-/// html_response(body, 200)
+/// json_response(body, 200)
 /// // -> Response(200, [#("content-type", "application/json")], Text(body))
 /// ```
 /// 


### PR DESCRIPTION
Potentialy a copy-paste error from the html_response function.