### PR TITLE
Update simplifile to 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.11.0 - 2024-02-03
+
+- Updated for simplifile v1.4 and replaced the deprecated `simplifile.is_file`
+  function with `simplifile.verify_is_file`.
+
 ## v0.10.0 - 2024-01-17
 
 - Relaxed version constraints for `gleam_stdlib` and `gleam_json` to permit 0.x

--- a/gleam.toml
+++ b/gleam.toml
@@ -17,7 +17,7 @@ gleam_http = "~> 3.5"
 gleam_json = "~> 0.6 or ~> 1.0"
 gleam_stdlib = "~> 0.29 or ~> 1.0"
 mist = "~> 0.13"
-simplifile = "~> 1.0"
+simplifile = "~> 1.4"
 marceau = "~> 1.1"
 
 [dev-dependencies]

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "wisp"
-version = "0.10.0"
+version = "0.11.0"
 gleam = ">= 0.32.0"
 description = "A practical web framework for Gleam"
 licences = ["Apache-2.0"]

--- a/manifest.toml
+++ b/manifest.toml
@@ -10,10 +10,10 @@ packages = [
   { name = "gleam_otp", version = "0.9.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "5FADBBEC5ECF3F8B6BE91101D432758503192AE2ADBAD5602158977341489F71" },
   { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "glisten", version = "0.9.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib", "gleam_otp"], otp_app = "glisten", source = "hex", outer_checksum = "C960B6CF25D4AABAB01211146E9B57E11827B9C49E4175217E0FB7EF5BCB0FF7" },
+  { name = "glisten", version = "0.9.2", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "glisten", source = "hex", outer_checksum = "C960B6CF25D4AABAB01211146E9B57E11827B9C49E4175217E0FB7EF5BCB0FF7" },
   { name = "marceau", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "1AAD727A30BE0F95562C3403BB9B27C823797AD90037714255EEBF617B1CDA81" },
-  { name = "mist", version = "0.15.0", build_tools = ["gleam"], requirements = ["gleam_otp", "gleam_http", "gleam_erlang", "glisten", "gleam_stdlib"], otp_app = "mist", source = "hex", outer_checksum = "49F51DDB64D7B2832F72727CC9721C478D6B524C96EA444C601A19D01E023C03" },
-  { name = "simplifile", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "359CD7006E2F69255025C858CCC6407C11A876EC179E6ED1E46809E8DC6B1AAD" },
+  { name = "mist", version = "0.15.0", build_tools = ["gleam"], requirements = ["gleam_otp", "gleam_stdlib", "gleam_http", "glisten", "gleam_erlang"], otp_app = "mist", source = "hex", outer_checksum = "49F51DDB64D7B2832F72727CC9721C478D6B524C96EA444C601A19D01E023C03" },
+  { name = "simplifile", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "AAFCF154F69B237D269FF2764890F61ABC4A7EF2A592D44D67627B99694539D9" },
   { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
 ]
 
@@ -27,4 +27,4 @@ gleam_stdlib = { version = "~> 0.29 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
 marceau = { version = "~> 1.1" }
 mist = { version = "~> 0.13" }
-simplifile = { version = "~> 1.0" }
+simplifile = { version = "~> 1.4" }

--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -1378,12 +1378,12 @@ pub fn serve_static(
         |> result.unwrap("")
         |> marceau.extension_to_mime_type
 
-      case simplifile.is_file(path) {
-        False -> handler()
-        True ->
+      case simplifile.verify_is_file(path) {
+        Ok(True) ->
           response.new(200)
           |> response.set_header("content-type", mime_type)
           |> response.set_body(File(path))
+        _ -> handler()
       }
     }
     _, _ -> handler()


### PR DESCRIPTION
While building a Wisp application, I was receiving a `deprecated value` notice due to simplifile:

```
warning: Deprecated value used
     ┌─ /Users/markholmes/Development/pf/app/backend/build/packages/wisp/src/wisp.gleam:1381:22
     │
1381 │       case simplifile.is_file(path) {
     │                      ^^^^^^^^ This value has been deprecated

It was deprecated with this message: Use `verify_is_file` instead
```

This PR seeks to address this warning by bumping simplifile to v1.4 and replacing usage of `simplifile.is_file` with `simplifile.verify_is_file`.