### PR TITLE
Fix example links in README docs

### DIFF
--- a/examples/01-routing/README.md
+++ b/examples/01-routing/README.md
@@ -11,7 +11,7 @@ request path and method.
 This example is based off of the ["Hello, World!" example][hello], so read that
 one first. The additions are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/0-hello-world
+[hello]: https://github.com/lpil/wisp/tree/main/examples/00-hello-world
 
 ### `app/router` module
 

--- a/examples/02-working-with-form-data/README.md
+++ b/examples/02-working-with-form-data/README.md
@@ -11,8 +11,8 @@ This example is based off of the ["Hello, World!" example][hello], and uses
 concepts from the [routing example][routing] so read those first. The additions
 are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/0-hello-world
-[routing]: https://github.com/lpil/wisp/tree/main/examples/1-routing
+[hello]: https://github.com/lpil/wisp/tree/main/examples/00-hello-world
+[routing]: https://github.com/lpil/wisp/tree/main/examples/01-routing
 
 ### `app/router` module
 

--- a/examples/03-working-with-json/README.md
+++ b/examples/03-working-with-json/README.md
@@ -12,8 +12,8 @@ This example is based off of the ["Hello, World!" example][hello], and uses
 concepts from the [routing example][routing] so read those first. The additions
 are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/0-hello-world
-[routing]: https://github.com/lpil/wisp/tree/main/examples/1-routing
+[hello]: https://github.com/lpil/wisp/tree/main/examples/00-hello-world
+[routing]: https://github.com/lpil/wisp/tree/main/examples/01-routing
 
 ### `gleam.toml` file
 

--- a/examples/04-working-with-other-formats/README.md
+++ b/examples/04-working-with-other-formats/README.md
@@ -13,8 +13,8 @@ This example is based off of the ["Hello, World!" example][hello], and uses
 concepts from the [routing example][routing] so read those first. The additions
 are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/0-hello-world
-[routing]: https://github.com/lpil/wisp/tree/main/examples/1-routing
+[hello]: https://github.com/lpil/wisp/tree/main/examples/00-hello-world
+[routing]: https://github.com/lpil/wisp/tree/main/examples/01-routing
 
 ### `gleam.toml` file
 

--- a/examples/05-using-a-database/README.md
+++ b/examples/05-using-a-database/README.md
@@ -11,7 +11,7 @@ database connection.
 This example is based off of the ["working with JSON" example][json], so read
 that first. The additions are detailed here and commented in the code.
 
-[json]: https://github.com/lpil/wisp/tree/main/examples/3-working-with-json
+[json]: https://github.com/lpil/wisp/tree/main/examples/03-working-with-json
 
 ### `gleam.toml` file
 

--- a/examples/06-serving-static-assets/README.md
+++ b/examples/06-serving-static-assets/README.md
@@ -11,7 +11,7 @@ request path and method.
 This example is based off of the ["Hello, World!" example][hello], so read that
 one first. The additions are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/1-routing
+[hello]: https://github.com/lpil/wisp/tree/main/examples/01-routing
 
 ### `priv/static` directory
 

--- a/examples/07-logging/README.md
+++ b/examples/07-logging/README.md
@@ -11,7 +11,7 @@ request path and method.
 This example is based off of the ["routing" example][routing], so read that
 one first. The additions are detailed here and commented in the code.
 
-[routing]: https://github.com/lpil/wisp/tree/main/examples/1-routing
+[routing]: https://github.com/lpil/wisp/tree/main/examples/01-routing
 
 ### `app/router` module
 

--- a/examples/08-working-with-cookies/README.md
+++ b/examples/08-working-with-cookies/README.md
@@ -17,7 +17,7 @@ someone gains access to the secret key they will be able to forge cookies. This
 example application generates a random string in `app.gleam`, but in a real
 application you will need to read this secret value from somewhere secure.
 
-[routing]: https://github.com/lpil/wisp/tree/main/examples/2-working-with-form-data
+[routing]: https://github.com/lpil/wisp/tree/main/examples/02-working-with-form-data
 
 ### `app/router` module
 

--- a/examples/09-configuring-default-responses/README.md
+++ b/examples/09-configuring-default-responses/README.md
@@ -15,7 +15,7 @@ You likely want your application to return a generic error page rather than an e
 This example is based off of the [routing example][routing] so read that first.
 The additions are detailed here and commented in the code.
 
-[routing]: https://github.com/lpil/wisp/tree/main/examples/1-routing
+[routing]: https://github.com/lpil/wisp/tree/main/examples/01-routing
 
 ### `app/router` module
 


### PR DESCRIPTION
Fix a bunch of broken example links in the README docs