### PR TITLE
Fix typos, inconsistencies, and a broken link in examples

### DIFF
--- a/examples/05-using-a-database/README.md
+++ b/examples/05-using-a-database/README.md
@@ -1,4 +1,4 @@
-# Wisp Example: Using A Database
+# Wisp Example: Using a database
 
 ```sh
 gleam run   # Run the server

--- a/examples/06-serving-static-assets/README.md
+++ b/examples/06-serving-static-assets/README.md
@@ -5,8 +5,9 @@ gleam run   # Run the server
 gleam test  # Run the tests
 ```
 
-This example shows how to route requests to different handlers based on the
-request path and method.
+This example shows how to serve static assets. In this case we'll serve
+a CSS file for page styling and a JavaScript file for updating the content
+of the HTML page, but the same techniques can also be used for other file types.
 
 This example is based off of the ["Hello, World!" example][hello], so read that
 one first. The additions are detailed here and commented in the code.

--- a/examples/07-logging/README.md
+++ b/examples/07-logging/README.md
@@ -5,8 +5,7 @@ gleam run   # Run the server
 gleam test  # Run the tests
 ```
 
-This example shows how to route requests to different handlers based on the
-request path and method.
+This example shows how to log messages using the BEAM logger.
 
 This example is based off of the ["routing" example][routing], so read that
 one first. The additions are detailed here and commented in the code.

--- a/examples/08-working-with-cookies/README.md
+++ b/examples/08-working-with-cookies/README.md
@@ -8,7 +8,7 @@ gleam test  # Run the tests
 This example shows how to read and write cookies, and how to sign cookies so
 they cannot be tampered with.
 
-This example is based off of the [working with form data example][form-data] so read that one
+This example is based off of the ["working with form data" example][form-data] so read that one
 first. The additions are detailed here and commented in the code.
 
 Signing of cookies uses the `secret_key_base` value. If this value changes then

--- a/examples/08-working-with-cookies/README.md
+++ b/examples/08-working-with-cookies/README.md
@@ -17,7 +17,7 @@ someone gains access to the secret key they will be able to forge cookies. This
 example application generates a random string in `app.gleam`, but in a real
 application you will need to read this secret value from somewhere secure.
 
-[routing]: https://github.com/lpil/wisp/tree/main/examples/02-working-with-form-data
+[form-data]: https://github.com/lpil/wisp/tree/main/examples/02-working-with-form-data
 
 ### `app/router` module
 

--- a/examples/09-configuring-default-responses/README.md
+++ b/examples/09-configuring-default-responses/README.md
@@ -12,7 +12,7 @@ request body contains invalid JSON.
 
 You likely want your application to return a generic error page rather than an empty body, and this example shows how to do that.
 
-This example is based off of the [routing example][routing] so read that first.
+This example is based off of the ["routing" example][routing] so read that first.
 The additions are detailed here and commented in the code.
 
 [routing]: https://github.com/lpil/wisp/tree/main/examples/01-routing

--- a/examples/10-working-with-files/README.md
+++ b/examples/10-working-with-files/README.md
@@ -7,7 +7,7 @@ gleam test  # Run the tests
 
 This example shows how to accept file uploads and allow users to download files.
 
-This example is based off of the ["Working with form data" example][formdata], 
+This example is based off of the ["working with form data" example][formdata],
 so read that first. The additions are detailed here and commented in the code.
 
 [formdata]: https://github.com/lpil/wisp/tree/main/examples/02-working-with-form-data

--- a/examples/10-working-with-files/src/app/router.gleam
+++ b/examples/10-working-with-files/src/app/router.gleam
@@ -51,8 +51,8 @@ fn handle_download_file_from_memory(req: Request) -> Response {
   |> wisp.set_header("content-type", "text/plain")
   // The content-disposition header is set by this function to ensure this is
   // treated as a file download. If the file was uploaded by the user then you
-  // want to ensure that this header is ste as otherwise the browser may try to
-  // display the file, which could enable in cross-site scripting attacks.
+  // want to ensure that this header is set as otherwise the browser may try to
+  // display the file, which could enable cross-site scripting attacks.
   |> wisp.file_download_from_memory(
     named: "hello.txt",
     containing: file_contents,
@@ -63,7 +63,7 @@ fn handle_download_file_from_disc(req: Request) -> Response {
   use <- wisp.require_method(req, Get)
 
   // In this case the file exists on the disc.
-  // Here's we're using the project README, but in a real application you'd
+  // Here we're using the project README, but in a real application you'd
   // probably have an absolute path to wherever it is you keep your files.
   let file_path = "./README.md"
 


### PR DESCRIPTION
In examples:
- fix a broken link
- improve consistency of readme headers and link texts
- fix some "this example shows how to..." paragraphs not matching their examples
- fix a few typos in comments in the "working with files" example