### PR TITLE
Add 'Security' param to get_cookie example

### DIFF
--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -1794,7 +1794,7 @@ pub type Security {
 /// for a signed cookie, then `Error(Nil)` is returned.
 ///
 /// ```gleam
-/// wisp.get_cookie(request, "group")
+/// wisp.get_cookie(request, "group", wisp.PlainText)
 /// // -> Ok("A")
 /// ```
 ///


### PR DESCRIPTION
The 'get_cookie' example is not in sync with the arguments required for this function.