### PR TITLE
(docs): Fix string_body example typo: using string_builder_body.

### DIFF
--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -360,7 +360,7 @@ pub fn string_builder_body(
 /// ```gleam
 /// let body = 
 /// response(201)
-/// |> string_builder_body("Hello, Joe!")
+/// |> string_body("Hello, Joe!")
 /// // -> Response(
 /// //   201,
 /// //   [],


### PR DESCRIPTION
There was a typo in string_body docs. 
Related issue: https://github.com/gleam-wisp/wisp/issues/74