### PR TITLE
update simplifile to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Updated simplifile to v2.0.0 and replaced the renamed `simplifile.verify_is_file`
+  function with `simplifile.is_file`.
 - The `mist` version constraint has been increased to >= 1.2.0.
 - The `escape_html` function in the `wisp` module has been optimised.
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -17,7 +17,7 @@ gleam_http = ">= 3.5.0 and < 4.0.0"
 gleam_json = ">= 0.6.0 and < 2.0.0"
 gleam_stdlib = ">= 0.29.0 and < 2.0.0"
 mist = ">= 1.2.0 and < 2.0.0"
-simplifile = ">= 1.4.0 and != 1.6.0 and < 2.0.0"
+simplifile = ">= 2.0.0 and < 3.0.0"
 marceau = ">= 1.1.0 and < 2.0.0"
 logging = ">= 1.0.0 and < 2.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -19,7 +19,7 @@ packages = [
   { name = "marceau", version = "1.2.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "5188D643C181EE350D8A20A3BDBD63AF7B6C505DE333CFBE05EF642ADD88A59B" },
   { name = "mist", version = "1.2.0", build_tools = ["gleam"], requirements = ["birl", "gleam_erlang", "gleam_http", "gleam_otp", "gleam_stdlib", "glisten", "gramps", "hpack_erl", "logging"], otp_app = "mist", source = "hex", outer_checksum = "109B4D64E68C104CC23BB3CC5441ECD479DD7444889DA01113B75C6AF0F0E17B" },
   { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
-  { name = "simplifile", version = "1.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "1D5DFA3A2F9319EC85825F6ED88B8E449F381B0D55A62F5E61424E748E7DDEB0" },
+  { name = "simplifile", version = "2.0.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "95219227A43FCFE62C6E494F413A1D56FF953B68FE420698612E3D89A1EFE029" },
   { name = "thoas", version = "1.2.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A" },
 ]
 
@@ -34,4 +34,4 @@ gleeunit = { version = "~> 1.0" }
 logging = { version = ">= 1.0.0 and < 2.0.0" }
 marceau = { version = ">= 1.1.0 and < 2.0.0" }
 mist = { version = ">= 1.2.0 and < 2.0.0" }
-simplifile = { version = ">= 1.4.0 and != 1.6.0 and < 2.0.0" }
+simplifile = { version = ">= 2.0.0 and < 3.0.0" }

--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -1598,7 +1598,7 @@ pub fn serve_static(
         |> result.unwrap("")
         |> marceau.extension_to_mime_type
 
-      case simplifile.verify_is_file(path) {
+      case simplifile.is_file(path) {
         Ok(True) ->
           response.new(200)
           |> response.set_header("content-type", mime_type)


### PR DESCRIPTION
:wave:

This PR updates simplifile to 2.0.0. The update required one code change due to a [renamed function in simplifile](https://github.com/bcpeinhardt/simplifile/blob/main/CHANGELOG.md#v200---1-june-2024).