### PR TITLE
Adding an example for using Prometheus metrics

### DIFF
--- a/examples/11-prometheus-metrics/README.md
+++ b/examples/11-prometheus-metrics/README.md
@@ -1,0 +1,44 @@
+# Wisp Example: Prometheus metrics
+
+```sh
+gleam run   # Run the server
+gleam test  # Run the tests
+```
+
+This example shows how to add HTTP instrumentation using [Prometheus](https://prometheus.io/docs/introduction/overview/)
+metrics to measure response times and count incoming requests per route and status code.
+
+This example is based off of the ["routing" example][routing], so read that
+one first. The additions are detailed here and commented in the code.
+
+[routing]: https://github.com/lpil/wisp/tree/main/examples/01-routing
+
+### How to test
+
+1. Run this example with `gleam run`
+2. Open some pages, e.g. [/comments/1](http://localhost:8000/comments/1)
+2. Check the metrics printed at [/metrics](http://localhost:8000/metrics)
+
+### `app/metrics` module
+
+This contains the logic for instrumentation:
+#### `create_standard_metrics()`
+
+This creates a `http_requests_total` [Counter](https://prometheus.io/docs/concepts/metric_types/#counter)
+and a `http_request_duration_seconds` [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram).
+
+This is called in the entrypoint (`app.gleam`) to initialise these metrics before the server starts.
+
+#### `record_http_metrics(Request) -> Response`
+
+This middleware is used in the main middleware chain (`app/web.gleam`). This executes the route handler while measuring its
+executing time, then records that in the `http_requests_total` and `http_request_duration_seconds` metrics.
+
+#### `print_metrics(Request) -> Response`
+
+This handler returns the metrics in the Prometheus text format. This is exposed on the `/metrics` route in `app/router.gleam`.
+
+#### `get_route_name(Request) -> String`
+
+This is an internal function which is used to generate the `route` label for requests. It's recommended to group the requests
+by some sort of request patterns (e.g. `/comments/:id`) instead of using the request path directly.

--- a/examples/11-prometheus-metrics/gleam.toml
+++ b/examples/11-prometheus-metrics/gleam.toml
@@ -1,0 +1,15 @@
+name = "app"
+version = "1.0.0"
+description = "A Wisp example"
+gleam = ">= 0.32.0"
+
+[dependencies]
+gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+promgleam = ">= 0.2.0 and < 1.0.0"
+wisp = ">= 0.15.0 and < 1.0.0"
+mist = ">= 1.2.0 and < 2.0.0"
+gleam_http = ">= 3.6.0 and < 4.0.0"
+gleam_erlang = ">= 0.25.0 and < 1.0.0"
+
+[dev-dependencies]
+gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/examples/11-prometheus-metrics/src/app.gleam
+++ b/examples/11-prometheus-metrics/src/app.gleam
@@ -1,0 +1,21 @@
+import app/metrics.{create_standard_metrics}
+import app/router
+import gleam/erlang/process
+import mist
+import wisp
+
+pub fn main() {
+  // Create the standard HTTP metrics by calling `create_standard_metrics()` here
+  create_standard_metrics()
+
+  wisp.configure_logger()
+  let secret_key_base = wisp.random_string(64)
+
+  let assert Ok(_) =
+    wisp.mist_handler(router.handle_request, secret_key_base)
+    |> mist.new
+    |> mist.port(8000)
+    |> mist.start_http
+
+  process.sleep_forever()
+}

--- a/examples/11-prometheus-metrics/src/app/metrics.gleam
+++ b/examples/11-prometheus-metrics/src/app/metrics.gleam
@@ -1,0 +1,99 @@
+import gleam/http
+import gleam/int
+import gleam/string
+import promgleam/metrics/counter.{create_counter, increment_counter}
+import promgleam/metrics/histogram.{create_histogram, observe_histogram}
+import promgleam/registry.{print_as_text}
+import promgleam/utils.{measure}
+import wisp
+
+const registy_name = "default"
+
+const http_requests_total = "http_requests_total"
+
+const http_request_duration_seconds = "http_request_duration_seconds"
+
+/// This creates a `http_requests_total` [Counter](https://prometheus.io/docs/concepts/metric_types/#counter)
+/// and a `http_request_duration_seconds` [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram).
+/// This is called in the entrypoint (`app.gleam`) to initialise these metrics before the server starts.
+pub fn create_standard_metrics() {
+  let assert Ok(_) =
+    create_counter(
+      registry: registy_name,
+      name: http_requests_total,
+      help: "Total number of HTTP requests",
+      labels: ["method", "route", "status"],
+    )
+
+  let assert Ok(_) =
+    create_histogram(
+      registry: registy_name,
+      name: http_request_duration_seconds,
+      help: "Duration of HTTP requests in seconds",
+      labels: ["method", "route", "status"],
+      // OpenTelemetry recommendation for histogram buckets of http request duration:
+      // https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
+      buckets: [
+        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0,
+        7.5, 10.0,
+      ],
+    )
+
+  Nil
+}
+
+/// This middleware is used in the main middleware chain (`app/web.gleam`). This executes the route handler
+/// while measuring its executing time, then records that in the `http_requests_total` and
+/// `http_request_duration_seconds` metrics.
+pub fn record_http_metrics(
+  req: wisp.Request,
+  handle_request: fn() -> wisp.Response,
+) -> wisp.Response {
+  let route_name = get_route_name(req)
+  let #(time_taken, response) = measure(handle_request)
+  let time_taken_in_seconds = int.to_float(time_taken) /. 1000.0
+  let method = string.uppercase(http.method_to_string(req.method))
+
+  let assert Ok(_) =
+    increment_counter(
+      registry: registy_name,
+      name: http_requests_total,
+      labels: [method, route_name, int.to_string(response.status)],
+      value: 1,
+    )
+
+  let assert Ok(_) =
+    observe_histogram(
+      registry: registy_name,
+      name: http_request_duration_seconds,
+      labels: [method, route_name, int.to_string(response.status)],
+      value: time_taken_in_seconds,
+    )
+
+  response
+}
+
+/// This handler returns the metrics in the Prometheus text format.
+/// This is exposed on the `/metrics` route in `app/router.gleam`.
+pub fn print_metrics(req: wisp.Request) -> wisp.Response {
+  // The metrics endpoint can only be accessed via GET requests.
+  use <- wisp.require_method(req, http.Get)
+
+  let body = print_as_text(registy_name)
+
+  wisp.ok()
+  |> wisp.string_body(body)
+}
+
+/// This is an internal function which is used to generate the `route` label for requests.
+/// It's recommended to group the requests by some sort of request patterns (e.g. `/comments/:id`)
+/// instead of using the request path directly.
+fn get_route_name(req: wisp.Request) -> String {
+  case wisp.path_segments(req) {
+    [] -> "/"
+    ["comments"] -> "/comments"
+    ["comments", _] -> "/comments:id"
+    ["metrics"] -> "/metrics"
+    _ -> req.path
+  }
+}

--- a/examples/11-prometheus-metrics/src/app/router.gleam
+++ b/examples/11-prometheus-metrics/src/app/router.gleam
@@ -1,0 +1,76 @@
+import app/metrics.{print_metrics}
+import app/web
+import gleam/http.{Get, Post}
+import gleam/string_builder
+import wisp.{type Request, type Response}
+
+pub fn handle_request(req: Request) -> Response {
+  use req <- web.middleware(req)
+
+  // Wisp doesn't have a special router abstraction, instead we recommend using
+  // regular old pattern matching. This is faster than a router, is type safe,
+  // and means you don't have to learn or be limited by a special DSL.
+  case wisp.path_segments(req) {
+    // This matches `/`.
+    [] -> home_page(req)
+
+    // This matches `/comments`.
+    ["comments"] -> comments(req)
+
+    // This matches `/comments/:id`.
+    // The `id` segment is bound to a variable and passed to the handler.
+    ["comments", id] -> show_comment(req, id)
+
+    // This matches `/metrics`.
+    // This returns the metrics in Prometheus text format.
+    ["metrics"] -> print_metrics(req)
+
+    // This matches all other paths.
+    _ -> wisp.not_found()
+  }
+}
+
+fn home_page(req: Request) -> Response {
+  // The home page can only be accessed via GET requests, so this middleware is
+  // used to return a 405: Method Not Allowed response for all other methods.
+  use <- wisp.require_method(req, Get)
+
+  let html = string_builder.from_string("Hello, Joe!")
+  wisp.ok()
+  |> wisp.html_body(html)
+}
+
+fn comments(req: Request) -> Response {
+  // This handler for `/comments` can respond to both GET and POST requests,
+  // so we pattern match on the method here.
+  case req.method {
+    Get -> list_comments()
+    Post -> create_comment(req)
+    _ -> wisp.method_not_allowed([Get, Post])
+  }
+}
+
+fn list_comments() -> Response {
+  // In a later example we'll show how to read from a database.
+  let html = string_builder.from_string("Comments!")
+  wisp.ok()
+  |> wisp.html_body(html)
+}
+
+fn create_comment(_req: Request) -> Response {
+  // In a later example we'll show how to parse data from the request body.
+  let html = string_builder.from_string("Created")
+  wisp.created()
+  |> wisp.html_body(html)
+}
+
+fn show_comment(req: Request, id: String) -> Response {
+  use <- wisp.require_method(req, Get)
+
+  // The `id` path parameter has been passed to this function, so we could use
+  // it to look up a comment in a database.
+  // For now we'll just include in the response body.
+  let html = string_builder.from_string("Comment with id " <> id)
+  wisp.ok()
+  |> wisp.html_body(html)
+}

--- a/examples/11-prometheus-metrics/src/app/web.gleam
+++ b/examples/11-prometheus-metrics/src/app/web.gleam
@@ -1,0 +1,18 @@
+import app/metrics.{record_http_metrics}
+import wisp
+
+pub fn middleware(
+  req: wisp.Request,
+  handle_request: fn(wisp.Request) -> wisp.Response,
+) -> wisp.Response {
+  let req = wisp.method_override(req)
+  use <- wisp.log_request(req)
+  use <- wisp.rescue_crashes
+
+  // Use the `record_http_metrics` middleware here
+  use <- record_http_metrics(req)
+
+  use req <- wisp.handle_head(req)
+
+  handle_request(req)
+}

--- a/examples/11-prometheus-metrics/test/app_test.gleam
+++ b/examples/11-prometheus-metrics/test/app_test.gleam
@@ -1,0 +1,49 @@
+import app/metrics.{create_standard_metrics}
+import app/router
+import gleam/list
+import gleam/string
+import gleeunit
+import gleeunit/should
+import wisp/testing
+
+pub fn main() {
+  gleeunit.main()
+}
+
+pub fn metrics_test() {
+  create_standard_metrics()
+
+  [
+    testing.get("/", []),
+    testing.get("/", []),
+    testing.get("/comments", []),
+    testing.get("/comments/1", []),
+    testing.get("/comments/2", []),
+    testing.get("/comments/3", []),
+  ]
+  |> list.each(router.handle_request)
+
+  let response = router.handle_request(testing.get("/metrics", []))
+
+  response.status |> should.equal(200)
+
+  let body = testing.string_body(response)
+
+  body
+  |> string.contains(
+    "http_request_duration_seconds_count{method=\"GET\",route=\"/\",status=\"200\"} 2",
+  )
+  |> should.be_true
+
+  body
+  |> string.contains(
+    "http_request_duration_seconds_count{method=\"GET\",route=\"/comments\",status=\"200\"} 1",
+  )
+  |> should.be_true
+
+  body
+  |> string.contains(
+    "http_request_duration_seconds_count{method=\"GET\",route=\"/comments:id\",status=\"200\"} 3",
+  )
+  |> should.be_true
+}


### PR DESCRIPTION
[Prometheus](https://prometheus.io/docs/introduction/overview/) is a widely used open-source systems monitoring and alerting toolkit. It's widely used for collecting metrics from different services and storing them in a time-series database, then querying the stored data using [PromQL](https://prometheus.io/docs/prometheus/latest/querying/basics/) and creating dashboard in e.g. [Grafana](https://prometheus.io/docs/visualization/grafana/) for application/system monitoring purposes.

To help the adaptation of Wisp in environments which standardise on Prometheus metrics for application monitoring, I recently started to work on a Gleam library called [PromGleam](https://hexdocs.pm/promgleam/) which provides Gleam bindings to the most popular [erlang Prometheus client](https://github.com/deadtrickster/prometheus.erl).
I also made this example project to demonstrate how to add PromGleam to a Wisp server to get some essential RED metrics (Rate, Errors, Duration) and expose them on the `/metrics` endpoint to a Prometheus scraper.