### PR TITLE
Mist module split

### DIFF
--- a/examples/00-hello-world/src/app.gleam
+++ b/examples/00-hello-world/src/app.gleam
@@ -1,7 +1,8 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   // This sets the logger to print INFO level logs, and other sensible defaults
@@ -14,7 +15,7 @@ pub fn main() {
 
   // Start the Mist web server.
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/01-routing/src/app.gleam
+++ b/examples/01-routing/src/app.gleam
@@ -1,14 +1,15 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
   let secret_key_base = wisp.random_string(64)
 
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/02-working-with-form-data/src/app.gleam
+++ b/examples/02-working-with-form-data/src/app.gleam
@@ -1,14 +1,15 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
   let secret_key_base = wisp.random_string(64)
 
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/03-working-with-json/src/app.gleam
+++ b/examples/03-working-with-json/src/app.gleam
@@ -1,14 +1,15 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
   let secret_key_base = wisp.random_string(64)
 
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/04-working-with-other-formats/src/app.gleam
+++ b/examples/04-working-with-other-formats/src/app.gleam
@@ -1,14 +1,15 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
   let secret_key_base = wisp.random_string(64)
 
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/05-using-a-database/src/app.gleam
+++ b/examples/05-using-a-database/src/app.gleam
@@ -1,9 +1,10 @@
-import gleam/erlang/process
-import tiny_database
-import mist
-import wisp
 import app/router
 import app/web
+import gleam/erlang/process
+import mist
+import tiny_database
+import wisp
+import wisp/wisp_mist
 
 pub const data_directory = "tmp/data"
 
@@ -24,7 +25,7 @@ pub fn main() {
 
   let assert Ok(_) =
     handler
-    |> wisp.mist_handler(secret_key_base)
+    |> wisp_mist.handler(secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/06-serving-static-assets/src/app.gleam
+++ b/examples/06-serving-static-assets/src/app.gleam
@@ -1,8 +1,9 @@
+import app/router
+import app/web.{Context}
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
-import app/web.{Context}
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
@@ -16,7 +17,7 @@ pub fn main() {
   let handler = router.handle_request(_, ctx)
 
   let assert Ok(_) =
-    wisp.mist_handler(handler, secret_key_base)
+    wisp_mist.handler(handler, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/07-logging/src/app.gleam
+++ b/examples/07-logging/src/app.gleam
@@ -1,14 +1,15 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
   let secret_key_base = wisp.random_string(64)
 
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/08-working-with-cookies/src/app.gleam
+++ b/examples/08-working-with-cookies/src/app.gleam
@@ -1,14 +1,15 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
   let secret_key_base = wisp.random_string(64)
 
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/09-configuring-default-responses/src/app.gleam
+++ b/examples/09-configuring-default-responses/src/app.gleam
@@ -1,14 +1,15 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
   let secret_key_base = wisp.random_string(64)
 
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/examples/10-working-with-files/src/app.gleam
+++ b/examples/10-working-with-files/src/app.gleam
@@ -1,14 +1,15 @@
+import app/router
 import gleam/erlang/process
 import mist
 import wisp
-import app/router
+import wisp/wisp_mist
 
 pub fn main() {
   wisp.configure_logger()
   let secret_key_base = wisp.random_string(64)
 
   let assert Ok(_) =
-    wisp.mist_handler(router.handle_request, secret_key_base)
+    wisp_mist.handler(router.handle_request, secret_key_base)
     |> mist.new
     |> mist.port(8000)
     |> mist.start_http

--- a/src/wisp/internal.gleam
+++ b/src/wisp/internal.gleam
@@ -1,0 +1,86 @@
+import gleam/bit_array
+import gleam/crypto
+import gleam/string
+
+// HELPERS
+
+//
+// Requests
+//
+
+/// The connection to the client for a HTTP request.
+///
+/// The body of the request can be read from this connection using functions
+/// such as `require_multipart_body`.
+///
+pub type Connection {
+  Connection(
+    reader: Reader,
+    max_body_size: Int,
+    max_files_size: Int,
+    read_chunk_size: Int,
+    secret_key_base: String,
+    temporary_directory: String,
+  )
+}
+
+pub fn make_connection(
+  body_reader: Reader,
+  secret_key_base: String,
+) -> Connection {
+  // TODO: replace `/tmp` with appropriate for the OS
+  let prefix = "/tmp/gleam-wisp/"
+  let temporary_directory = join_path(prefix, random_slug())
+  Connection(
+    reader: body_reader,
+    max_body_size: 8_000_000,
+    max_files_size: 32_000_000,
+    read_chunk_size: 1_000_000,
+    temporary_directory: temporary_directory,
+    secret_key_base: secret_key_base,
+  )
+}
+
+type Reader =
+  fn(Int) -> Result(Read, Nil)
+
+pub type Read {
+  Chunk(BitArray, next: Reader)
+  ReadingFinished
+}
+
+//
+// Middleware Helpers
+//
+
+pub fn remove_preceeding_slashes(string: String) -> String {
+  case string {
+    "/" <> rest -> remove_preceeding_slashes(rest)
+    _ -> string
+  }
+}
+
+// TODO: replace with simplifile function when it exists
+pub fn join_path(a: String, b: String) -> String {
+  let b = remove_preceeding_slashes(b)
+  case string.ends_with(a, "/") {
+    True -> a <> b
+    False -> a <> "/" <> b
+  }
+}
+
+//
+// Cryptography
+//
+
+/// Generate a random string of the given length.
+///
+pub fn random_string(length: Int) -> String {
+  crypto.strong_random_bytes(length)
+  |> bit_array.base64_url_encode(False)
+  |> string.slice(0, length)
+}
+
+pub fn random_slug() -> String {
+  random_string(16)
+}

--- a/src/wisp/wisp_mist.gleam
+++ b/src/wisp/wisp_mist.gleam
@@ -1,0 +1,96 @@
+import exception
+import gleam/bytes_builder
+import gleam/http/request.{type Request as HttpRequest}
+import gleam/http/response.{type Response as HttpResponse}
+import gleam/option
+import gleam/result
+import gleam/string
+import mist
+import wisp
+import wisp/internal
+
+//
+// Running the server
+//
+
+/// Convert a Wisp request handler into a function that can be run with the Mist
+/// web server.
+///
+/// # Examples
+///
+/// ```gleam
+/// pub fn main() {
+///   let secret_key_base = "..."
+///   let assert Ok(_) =
+///     handle_request
+///     |> wisp_mist.handler(secret_key_base)
+///     |> mist.new
+///     |> mist.port(8000)
+///     |> mist.start_http
+///   process.sleep_forever()
+/// }
+/// ```
+pub fn handler(
+  handler: fn(wisp.Request) -> wisp.Response,
+  secret_key_base: String,
+) -> fn(HttpRequest(mist.Connection)) -> HttpResponse(mist.ResponseData) {
+  fn(request: HttpRequest(_)) {
+    let connection =
+      internal.make_connection(mist_body_reader(request), secret_key_base)
+    let request = request.set_body(request, connection)
+
+    use <- exception.defer(fn() {
+      let assert Ok(_) = wisp.delete_temporary_files(request)
+    })
+
+    let response =
+      request
+      |> handler
+      |> mist_response
+
+    response
+  }
+}
+
+fn mist_body_reader(request: HttpRequest(mist.Connection)) -> internal.Reader {
+  case mist.stream(request) {
+    Error(_) -> fn(_) { Ok(internal.ReadingFinished) }
+    Ok(stream) -> fn(size) { wrap_mist_chunk(stream(size)) }
+  }
+}
+
+fn wrap_mist_chunk(
+  chunk: Result(mist.Chunk, mist.ReadError),
+) -> Result(internal.Read, Nil) {
+  chunk
+  |> result.nil_error
+  |> result.map(fn(chunk) {
+    case chunk {
+      mist.Done -> internal.ReadingFinished
+      mist.Chunk(data, consume) ->
+        internal.Chunk(data, fn(size) { wrap_mist_chunk(consume(size)) })
+    }
+  })
+}
+
+fn mist_response(response: wisp.Response) -> HttpResponse(mist.ResponseData) {
+  let body = case response.body {
+    wisp.Empty -> mist.Bytes(bytes_builder.new())
+    wisp.Text(text) -> mist.Bytes(bytes_builder.from_string_builder(text))
+    wisp.Bytes(bytes) -> mist.Bytes(bytes)
+    wisp.File(path) -> mist_send_file(path)
+  }
+  response
+  |> response.set_body(body)
+}
+
+fn mist_send_file(path: String) -> mist.ResponseData {
+  case mist.send_file(path, offset: 0, limit: option.None) {
+    Ok(body) -> body
+    Error(error) -> {
+      wisp.log_error(string.inspect(error))
+      // TODO: return 500
+      mist.Bytes(bytes_builder.new())
+    }
+  }
+}


### PR DESCRIPTION
Preceding pr #72 and comment: https://github.com/gleam-wisp/wisp/pull/72#pullrequestreview-2176235813

This is just the split of the existing mist functions and code from the main wisp module.

An internal module has been added to allow code share between wisp and any web server implementation such as mist.

Mist has been entirely removed from the main wisp.gleam and wisp/internal.gleam files.