### PR TITLE
Use the directories package to detect a temp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The Mist web server related functions have been moved to the `wisp_mist`
   module.
 - The `wisp` module gains the `set_logger_level` function and `LogLevel` type.
+- Rather than using `/tmp`, the platform-specific temporary directory is detected used
 
 ## v0.16.0 - 2024-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## v1.0.0 - Unreleased
+## v1.1.0 - Unreleased
+
+- Rather than using `/tmp`, the platform-specific temporary directory is detected used
+
+## v1.0.0 - 2024-08-21
 
 - The Mist web server related functions have been moved to the `wisp_mist`
   module.
 - The `wisp` module gains the `set_logger_level` function and `LogLevel` type.
-- Rather than using `/tmp`, the platform-specific temporary directory is detected used
 
 ## v0.16.0 - 2024-07-13
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -18,6 +18,7 @@ mist = ">= 1.2.0 and < 3.0.0"
 simplifile = ">= 2.0.0 and < 3.0.0"
 marceau = ">= 1.1.0 and < 2.0.0"
 logging = ">= 1.2.0 and < 2.0.0"
+directories = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,6 +3,8 @@
 
 packages = [
   { name = "birl", version = "1.7.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "5C66647D62BCB11FE327E7A6024907C4A17954EF22865FE0940B54A852446D01" },
+  { name = "directories", version = "1.0.0", build_tools = ["gleam"], requirements = ["envoy", "gleam_erlang", "gleam_stdlib", "simplifile"], otp_app = "directories", source = "hex", outer_checksum = "8691C1581C6D8FB7EF390127B096B308D2ED05BCA90468B1D1218DE5AB5C4B04" },
+  { name = "envoy", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "CFAACCCFC47654F7E8B75E614746ED924C65BD08B1DE21101548AC314A8B6A41" },
   { name = "exception", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "F5580D584F16A20B7FCDCABF9E9BE9A2C1F6AC4F9176FA6DD0B63E3B20D450AA" },
   { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
   { name = "gleam_crypto", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_crypto", source = "hex", outer_checksum = "ADD058DEDE8F0341F1ADE3AAC492A224F15700829D9A3A3F9ADF370F875C51B7" },
@@ -25,6 +27,7 @@ packages = [
 ]
 
 [requirements]
+directories = { version = ">= 1.0.0 and < 2.0.0" }
 exception = { version = ">= 2.0.0 and < 3.0.0" }
 gleam_crypto = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.21.0 and < 2.0.0" }

--- a/src/wisp/internal.gleam
+++ b/src/wisp/internal.gleam
@@ -1,7 +1,6 @@
 import directories
 import gleam/bit_array
 import gleam/crypto
-import gleam/result
 import gleam/string
 
 // HELPERS
@@ -31,7 +30,10 @@ pub fn make_connection(
   secret_key_base: String,
 ) -> Connection {
   // Fallback to current working directory when no valid tmp directory exists
-  let prefix = result.unwrap(directories.tmp_dir(), ".") <> "/gleam-wisp/"
+  let prefix = case directories.tmp_dir() {
+    Ok(tmp_dir) -> tmp_dir <> "/gleam-wisp/"
+    Error(_) -> "./tmp/"
+  }
   let temporary_directory = join_path(prefix, random_slug())
   Connection(
     reader: body_reader,

--- a/src/wisp/internal.gleam
+++ b/src/wisp/internal.gleam
@@ -1,5 +1,7 @@
+import directories
 import gleam/bit_array
 import gleam/crypto
+import gleam/result
 import gleam/string
 
 // HELPERS
@@ -28,8 +30,8 @@ pub fn make_connection(
   body_reader: Reader,
   secret_key_base: String,
 ) -> Connection {
-  // TODO: replace `/tmp` with appropriate for the OS
-  let prefix = "/tmp/gleam-wisp/"
+  // Fallback to current working directory when no valid tmp directory exists
+  let prefix = result.unwrap(directories.tmp_dir(), ".") <> "/gleam-wisp/"
   let temporary_directory = join_path(prefix, random_slug())
   Connection(
     reader: body_reader,


### PR DESCRIPTION
Fixes #9 

As `directories.tmp_file()` returning `Error(Nil)` means that `/tmp/` or similar didn't exist, a good fallback would be the current working directory