### PR TITLE
Typo.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
       <li>Type safe routing with good old fashioned pattern matching.</li>
       <li>Parsing of JSON, urlencoded, and multipart bodies.</li>
       <li>Tamper-proof signed cookies, suitable for authentication.</li>
-      <li>Body size limiting and file upload streaming to disc, to prevent
+      <li>Body size limiting and file upload streaming to disk, to prevent
         memory exhaustion attacks.</li>
       <li>Serving of CSS, JavaScript, or whatever other static assets you want.</li>
       <li>Logging, both ad-hoc logging and request logging, using a middleware.</li>


### PR DESCRIPTION
Fix disk (from hard disk) was written as disc.