### PR TITLE
Feat: add serve static with

### DIFF
--- a/src/wisp/internal.gleam
+++ b/src/wisp/internal.gleam
@@ -1,7 +1,10 @@
 import directories
 import gleam/bit_array
 import gleam/crypto
+import gleam/int
+import gleam/result
 import gleam/string
+import simplifile
 
 // HELPERS
 
@@ -87,4 +90,16 @@ pub fn random_string(length: Int) -> String {
 
 pub fn random_slug() -> String {
   random_string(16)
+}
+
+/// Generates etag using file size + file mtime as seconds
+///
+/// Exmaple etag value: `2C-67A4D2F1`
+pub fn generate_etag(path: String) -> Result(String, simplifile.FileError) {
+  use file_info <- result.try(simplifile.file_info(path))
+  Ok(
+    int.to_base16(file_info.size)
+    <> "-"
+    <> int.to_base16(file_info.mtime_seconds),
+  )
 }

--- a/test/wisp_test.gleam
+++ b/test/wisp_test.gleam
@@ -16,6 +16,7 @@ import gleeunit
 import gleeunit/should
 import simplifile
 import wisp
+import wisp/internal
 import wisp/testing
 
 pub fn main() {
@@ -455,6 +456,292 @@ pub fn serve_static_go_up_test() {
     wisp.ok()
   }
   |> should.equal(wisp.ok())
+}
+
+pub fn serve_static_with_default_test() {
+  let handler = fn(request) {
+    use <- wisp.serve_static_with(
+      request,
+      under: "/stuff",
+      from: "./",
+      options: wisp.ServeStaticOptions(
+        etags: False,
+        response_headers: wisp.ResponseHeaders([]),
+      ),
+    )
+    wisp.ok()
+  }
+
+  // Get a text file
+  let response =
+    testing.get("/stuff/test/fixture.txt", [])
+    |> handler
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "text/plain; charset=utf-8"),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.txt"))
+
+  // Get a json file
+  let response =
+    testing.get("/stuff/test/fixture.json", [])
+    |> handler
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "application/json; charset=utf-8"),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.json"))
+
+  // Get some other file
+  let response =
+    testing.get("/stuff/test/fixture.dat", [])
+    |> handler
+  should.equal(response.status, 200)
+  should.equal(response.headers, [#("content-type", "application/octet-stream")])
+  should.equal(response.body, wisp.File("./test/fixture.dat"))
+
+  // Get something not handled by the static file server
+  let response =
+    testing.get("/stuff/this-does-not-exist", [])
+    |> handler
+  should.equal(response.status, 200)
+  should.equal(response.headers, [])
+  should.equal(response.body, wisp.Empty)
+}
+
+pub fn serve_static_with_applies_to_correct_file_test() {
+  let handler = fn(request) {
+    use <- wisp.serve_static_with(
+      request,
+      under: "/stuff",
+      from: "./",
+      options: wisp.ServeStaticOptions(
+        etags: False,
+        response_headers: wisp.ResponseHeadersFor(
+          file_types: ["txt", "json"],
+          headers: [#("cache-control", "immutable")],
+        ),
+      ),
+    )
+    wisp.ok()
+  }
+
+  // Get a text file
+  let response =
+    testing.get("/stuff/test/fixture.txt", [])
+    |> handler
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "text/plain; charset=utf-8"),
+    #("cache-control", "immutable"),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.txt"))
+
+  // Get a json file
+  let response =
+    testing.get("/stuff/test/fixture.json", [])
+    |> handler
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "application/json; charset=utf-8"),
+    #("cache-control", "immutable"),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.json"))
+
+  // Get some other file
+  let response =
+    testing.get("/stuff/test/fixture.dat", [])
+    |> handler
+  should.equal(response.status, 200)
+  should.equal(response.headers, [#("content-type", "application/octet-stream")])
+  should.equal(response.body, wisp.File("./test/fixture.dat"))
+
+  // Get something not handled by the static file server
+  let response =
+    testing.get("/stuff/this-does-not-exist", [])
+    |> handler
+  should.equal(response.status, 200)
+  should.equal(response.headers, [])
+  should.equal(response.body, wisp.Empty)
+}
+
+pub fn serve_static_with_etags_test() {
+  let handler = fn(request) {
+    use <- wisp.serve_static_with(
+      request,
+      under: "/stuff",
+      from: "./",
+      options: wisp.ServeStaticOptions(
+        etags: True,
+        response_headers: wisp.ResponseHeaders([]),
+      ),
+    )
+    wisp.ok()
+  }
+
+  // Get a text file
+  let response =
+    testing.get("/stuff/test/fixture.txt", [])
+    |> handler
+  let assert Ok(etag) = internal.generate_etag("test/fixture.txt")
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "text/plain; charset=utf-8"),
+    #("etag", etag),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.txt"))
+
+  // Get a json file
+  let response =
+    testing.get("/stuff/test/fixture.json", [])
+    |> handler
+  let assert Ok(etag) = internal.generate_etag("test/fixture.json")
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "application/json; charset=utf-8"),
+    #("etag", etag),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.json"))
+
+  // Get some other file
+  let response =
+    testing.get("/stuff/test/fixture.dat", [])
+    |> handler
+  let assert Ok(etag) = internal.generate_etag("test/fixture.dat")
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "application/octet-stream"),
+    #("etag", etag),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.dat"))
+
+  // Get something not handled by the static file server
+  let response =
+    testing.get("/stuff/this-does-not-exist", [])
+    |> handler
+  should.equal(response.status, 200)
+  should.equal(response.headers, [])
+  should.equal(response.body, wisp.Empty)
+}
+
+pub fn serve_static_with_etags_returns_304_test() {
+  let handler = fn(request) {
+    use <- wisp.serve_static_with(
+      request,
+      under: "/stuff",
+      from: "./",
+      options: wisp.ServeStaticOptions(
+        etags: True,
+        response_headers: wisp.ResponseHeaders([]),
+      ),
+    )
+    wisp.ok()
+  }
+
+  // Get a text file without any headers
+  let response =
+    testing.get("/stuff/test/fixture.txt", [])
+    |> handler
+  let assert Ok(txt_etag) = internal.generate_etag("test/fixture.txt")
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "text/plain; charset=utf-8"),
+    #("etag", txt_etag),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.txt"))
+
+  // Get a text file with outdated if-none-match header
+  let response =
+    testing.get("/stuff/test/fixture.txt", [#("if-none-match", "invalid-etag")])
+    |> handler
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "text/plain; charset=utf-8"),
+    #("etag", txt_etag),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.txt"))
+
+  // Get a text file with current etag in if-none-match header
+  let response =
+    testing.get("/stuff/test/fixture.txt", [#("if-none-match", txt_etag)])
+    |> handler
+
+  should.equal(response.status, 304)
+  should.equal(response.headers, [])
+  should.equal(response.body, wisp.Empty)
+}
+
+pub fn serve_static_with_etags_and_custom_headers_test() {
+  let handler = fn(request) {
+    use <- wisp.serve_static_with(
+      request,
+      under: "/stuff",
+      from: "./",
+      options: wisp.ServeStaticOptions(
+        etags: True,
+        response_headers: wisp.ResponseHeadersFor(file_types: ["txt"], headers: [
+          #("cache-control", "max-age=604800"),
+        ]),
+      ),
+    )
+    wisp.ok()
+  }
+
+  // Get a text file without any headers
+  let response =
+    testing.get("/stuff/test/fixture.txt", [])
+    |> handler
+  let assert Ok(txt_etag) = internal.generate_etag("test/fixture.txt")
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "text/plain; charset=utf-8"),
+    #("cache-control", "max-age=604800"),
+    #("etag", txt_etag),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.txt"))
+
+  // Get a text file with outdated if-none-match header
+  let response =
+    testing.get("/stuff/test/fixture.txt", [#("if-none-match", "invalid-etag")])
+    |> handler
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "text/plain; charset=utf-8"),
+    #("cache-control", "max-age=604800"),
+    #("etag", txt_etag),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.txt"))
+
+  // Get a text file with current etag in if-none-match header
+  let response =
+    testing.get("/stuff/test/fixture.txt", [#("if-none-match", txt_etag)])
+    |> handler
+
+  should.equal(response.status, 304)
+  should.equal(response.headers, [])
+  should.equal(response.body, wisp.Empty)
+
+  // Get a json file, custom header should not be applied
+  let response =
+    testing.get("/stuff/test/fixture.json", [])
+    |> handler
+  let assert Ok(json_etag) = internal.generate_etag("test/fixture.json")
+
+  should.equal(response.status, 200)
+  should.equal(response.headers, [
+    #("content-type", "application/json; charset=utf-8"),
+    #("etag", json_etag),
+  ])
+  should.equal(response.body, wisp.File("./test/fixture.json"))
 }
 
 pub fn temporary_file_test() {


### PR DESCRIPTION
Resolves #103 

Adds a new function `serve_static_with` which takes options for enabling etags and setting response headers for specific file types.



