### PR TITLE
Use houdini to escape html

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -19,6 +19,7 @@ simplifile = ">= 2.0.0 and < 3.0.0"
 marceau = ">= 1.1.0 and < 2.0.0"
 logging = ">= 1.2.0 and < 2.0.0"
 directories = ">= 1.0.0 and < 2.0.0"
+houdini = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -16,6 +16,7 @@ packages = [
   { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
   { name = "glisten", version = "7.0.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib", "logging", "telemetry"], otp_app = "glisten", source = "hex", outer_checksum = "1A53CF9FB3231A93FF7F1BD519A43DC968C1722F126CDD278403A78725FC5189" },
   { name = "gramps", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gramps", source = "hex", outer_checksum = "59194B3980110B403EE6B75330DB82CDE05FC8138491C2EAEACBC7AAEF30B2E8" },
+  { name = "houdini", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "houdini", source = "hex", outer_checksum = "799BECC222753D60FA0809B2FD5280B7C0C3FE853380B5EF78D58FE81156F01C" },
   { name = "hpack_erl", version = "0.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "hpack", source = "hex", outer_checksum = "D6137D7079169D8C485C6962DFE261AF5B9EF60FBC557344511C1E65E3D95FB0" },
   { name = "logging", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "logging", source = "hex", outer_checksum = "1098FBF10B54B44C2C7FDF0B01C1253CAFACDACABEFB4B0D027803246753E06D" },
   { name = "marceau", version = "1.3.0", build_tools = ["gleam"], requirements = [], otp_app = "marceau", source = "hex", outer_checksum = "2D1C27504BEF45005F5DFB18591F8610FB4BFA91744878210BDC464412EC44E9" },
@@ -34,6 +35,7 @@ gleam_http = { version = ">= 3.5.0 and < 5.0.0" }
 gleam_json = { version = ">= 0.6.0 and < 3.0.0" }
 gleam_stdlib = { version = ">= 0.43.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
+houdini = { version = ">= 1.0.0 and < 2.0.0" }
 logging = { version = ">= 1.2.0 and < 2.0.0" }
 marceau = { version = ">= 1.1.0 and < 2.0.0" }
 mist = { version = ">= 1.2.0 and < 5.0.0" }

--- a/src/wisp_ffi.erl
+++ b/src/wisp_ffi.erl
@@ -1,4 +1,0 @@
--module(wisp_ffi).
--export([coerce/1]).
-
-coerce(X) -> X.

--- a/test/wisp_test.gleam
+++ b/test/wisp_test.gleam
@@ -973,7 +973,7 @@ pub fn create_canned_connection_test() {
 pub fn escape_html_test() {
   "<script>alert('&');</script>"
   |> wisp.escape_html
-  |> should.equal("&lt;script&gt;alert('&amp;');&lt;/script&gt;")
+  |> should.equal("&lt;script&gt;alert(&#39;&amp;&#39;);&lt;/script&gt;")
 }
 
 pub fn set_header_test() {


### PR DESCRIPTION
This PR adds `houdini` as a dependency used to escape HTML. Houdini is basically that same piece of code plus some tweaks to make it even faster! Also turns out wisp wasn't escaping `'` characters, so I've updated one of the failing tests