### PR TITLE
Do not redirect on 304

### DIFF
--- a/examples/09-configuring-default-responses/src/app/web.gleam
+++ b/examples/09-configuring-default-responses/src/app/web.gleam
@@ -50,7 +50,7 @@ pub fn default_responses(handle_request: fn() -> wisp.Response) -> wisp.Response
       |> string_tree.from_string
       |> wisp.html_body(response, _)
 
-    // For other status codes redirect to the home page
-    _ -> wisp.redirect("/")
+    // For other status codes return the original response
+    _ -> response
   }
 }


### PR DESCRIPTION
Given that 304 is used for the etag. This default responses middleware should not change the 304 to a 303. Same for other status codes not explicitly handled.