### PR TITLE
Implement `range` request header support

### DIFF
--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -54,7 +54,7 @@ pub type Body {
   /// safe to send large files this way.
   ///
   File(path: String)
-  /// A body of a chunk of the contents of a file.
+  /// A body with a chunk of the contents of a file.
   ///
   /// This will be sent efficiently using the `send_file` function of the
   /// underlying HTTP server. The file will not be read into memory so it is
@@ -1410,6 +1410,8 @@ type ValidRangeHeader {
   ValidRangeHeader(offset: Int, limit: Option(Int))
 }
 
+/// Parses request range headers and validates that the range is in bounds of the file.
+/// If the range is out of bounds, it will return an error with a `416 Range Not Satisfiable` response.
 fn parse_range_header(
   range_header: String,
   file_size: Int,
@@ -1463,9 +1465,10 @@ fn parse_range_header(
 }
 
 /// Checks for the `range` header and handles partial file reads.
-/// If the range header is present, it will set the `accept-ranges`, `content-range`, and `content-length` headers.
+/// If the range request header is present, it will set the `accept-ranges`, `content-range`, and `content-length` response headers.
+/// If the raange request header has a range that is out of bounds of the file, it will respond with a `416 Range Not Satisfiable`.
 ///
-/// If the header isn't present, it returns the file without adding any additional headers.
+/// If the header isn't present, it returns the input response without changes.
 fn handle_range_header(
   resp: Response,
   req: Request,

--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -54,6 +54,13 @@ pub type Body {
   /// safe to send large files this way.
   ///
   File(path: String)
+  /// A body of a chunk of the contents of a file.
+  ///
+  /// This will be sent efficiently using the `send_file` function of the
+  /// underlying HTTP server. The file will not be read into memory so it is
+  /// safe to send large files this way.
+  ///
+  FileChunk(path: String, offset: Int, limit: Option(Int))
   /// An empty body. This may be returned by the `require_*` middleware
   /// functions in the event of a failure, invalid request, or other situation
   /// in which the request cannot be processed.
@@ -1388,6 +1395,7 @@ pub fn serve_static(
               |> response.set_header("content-type", content_type)
               |> response.set_body(File(path))
               |> handle_etag(req, file_info)
+              |> handle_range_header(req, file_info, path)
             }
             _ -> handler()
           }
@@ -1396,6 +1404,110 @@ pub fn serve_static(
     }
     _, _ -> handler()
   }
+}
+
+type ValidRangeHeader {
+  ValidRangeHeader(offset: Int, limit: Option(Int))
+}
+
+fn parse_range_header(
+  range_header: String,
+  file_size: Int,
+) -> Result(ValidRangeHeader, Response) {
+  use #(offset, limit) <- result.try(
+    case range_header {
+      "bytes=" <> range -> {
+        use #(start_str, end_str) <- result.try(range |> string.split_once("-"))
+
+        case start_str, end_str {
+          // "range: bytes=-[tail]"
+          "", _ ->
+            int.parse(end_str)
+            |> result.map(fn(tail_offset) {
+              #(file_size - tail_offset, option.None)
+            })
+
+          // "range: bytes=[start]-"
+          _, "" ->
+            int.parse(start_str)
+            |> result.map(fn(offset) { #(offset, option.None) })
+
+          // "range: bytes=[start]-[end]"
+          _, _ -> {
+            use start <- result.try(int.parse(start_str))
+            use end <- result.try(int.parse(end_str))
+
+            Ok(#(start, option.Some(end - start + 1)))
+          }
+        }
+      }
+      _ -> Error(Nil)
+    }
+    |> result.replace_error(bad_request()),
+  )
+
+  let end_is_invalid =
+    limit
+    |> option.map(fn(end) { end < 0 || end >= file_size })
+    |> option.unwrap(False)
+
+  use <- bool.guard(
+    offset < 0 || offset >= file_size || end_is_invalid,
+    Error(
+      response(416)
+      |> response.prepend_header("range", "bytes=*"),
+    ),
+  )
+
+  Ok(ValidRangeHeader(offset:, limit:))
+}
+
+/// Checks for the `range` header and handles partial file reads.
+/// If the range header is present, it will set the `accept-ranges`, `content-range`, and `content-length` headers.
+///
+/// If the header isn't present, it returns the file without adding any additional headers.
+fn handle_range_header(
+  resp: Response,
+  req: Request,
+  file_info: simplifile.FileInfo,
+  path: String,
+) -> Response {
+  {
+    use range <- result.try(
+      request.get_header(req, "range") |> result.replace_error(resp),
+    )
+
+    use ValidRangeHeader(offset:, limit:) <- result.try(parse_range_header(
+      range,
+      file_info.size,
+    ))
+
+    let content_range = {
+      let end = case limit {
+        option.Some(l) -> { offset + l - 1 } |> int.to_string
+        option.None -> { file_info.size - 1 } |> int.max(0) |> int.to_string
+      }
+
+      "bytes "
+      <> int.to_string(offset)
+      <> "-"
+      <> end
+      <> "/"
+      <> int.to_string(file_info.size)
+    }
+
+    let content_length = case limit {
+      option.Some(l) -> int.to_string(l)
+      option.None -> int.to_string(file_info.size - offset)
+    }
+
+    response.Response(206, resp.headers, FileChunk(path, offset, limit))
+    |> response.set_header("content-length", content_length)
+    |> response.prepend_header("accept-ranges", "bytes")
+    |> response.prepend_header("content-range", content_range)
+    |> Ok
+  }
+  |> result.unwrap_both
 }
 
 /// Calculates etag for requested file and then checks for the request header `if-none-match`.

--- a/src/wisp/testing.gleam
+++ b/src/wisp/testing.gleam
@@ -9,7 +9,7 @@ import gleam/string
 import gleam/string_tree
 import gleam/uri
 import simplifile
-import wisp.{type Request, type Response, Bytes, Empty, File, Text}
+import wisp.{type Request, type Response, Bytes, Empty, File, FileChunk, Text}
 
 /// The default secret key base used for test requests.
 /// This should never be used outside of tests.
@@ -237,6 +237,11 @@ pub fn string_body(response: Response) -> String {
       let assert Ok(contents) = simplifile.read(path)
       contents
     }
+    FileChunk(path, offset, limit) -> {
+      let assert Ok(contents) = simplifile.read(path)
+      let length = limit |> option.unwrap(string.length(contents))
+      contents |> string.slice(offset, length)
+    }
   }
 }
 
@@ -255,6 +260,12 @@ pub fn bit_array_body(response: Response) -> BitArray {
     File(path) -> {
       let assert Ok(contents) = simplifile.read_bits(path)
       contents
+    }
+    FileChunk(path, offset, limit) -> {
+      let assert Ok(contents) = simplifile.read_bits(path)
+      let length = limit |> option.unwrap(bit_array.byte_size(contents))
+      let assert Ok(sliced) = contents |> bit_array.slice(offset, length)
+      sliced
     }
   }
 }

--- a/src/wisp/wisp_mist.gleam
+++ b/src/wisp/wisp_mist.gleam
@@ -78,14 +78,19 @@ fn mist_response(response: wisp.Response) -> HttpResponse(mist.ResponseData) {
     wisp.Empty -> mist.Bytes(bytes_tree.new())
     wisp.Text(text) -> mist.Bytes(bytes_tree.from_string_tree(text))
     wisp.Bytes(bytes) -> mist.Bytes(bytes)
-    wisp.File(path) -> mist_send_file(path)
+    wisp.File(path) -> mist_send_file(path, 0, option.None)
+    wisp.FileChunk(path, offset, limit) -> mist_send_file(path, offset, limit)
   }
   response
   |> response.set_body(body)
 }
 
-fn mist_send_file(path: String) -> mist.ResponseData {
-  case mist.send_file(path, offset: 0, limit: option.None) {
+fn mist_send_file(
+  path: String,
+  offset: Int,
+  limit: option.Option(Int),
+) -> mist.ResponseData {
+  case mist.send_file(path, offset:, limit:) {
     Ok(body) -> body
     Error(error) -> {
       wisp.log_error(string.inspect(error))

--- a/test/wisp_test.gleam
+++ b/test/wisp_test.gleam
@@ -9,6 +9,7 @@ import gleam/http/request
 import gleam/http/response.{Response}
 import gleam/int
 import gleam/list
+import gleam/option
 import gleam/result
 import gleam/set
 import gleam/string
@@ -552,6 +553,83 @@ pub fn serve_static_etags_returns_304_test() {
   should.equal(response.status, 304)
   should.equal(response.headers, [])
   should.equal(response.body, wisp.Empty)
+}
+
+pub fn serve_static_range_request_test() {
+  let handler = fn(request) {
+    use <- wisp.serve_static(request, under: "/stuff", from: "./test")
+    wisp.ok()
+  }
+
+  let validate_content_range = fn(
+    response: response.Response(wisp.Body),
+    start: Int,
+    end: Int,
+    file_info: simplifile.FileInfo,
+  ) -> Nil {
+    let file_size = file_info.size
+    response.status
+    |> should.equal(206)
+
+    let headers =
+      response.headers
+      |> dict.from_list
+
+    headers
+    |> dict.get("accept-ranges")
+    |> should.equal(Ok("bytes"))
+
+    headers
+    |> dict.get("content-range")
+    |> should.equal(Ok(
+      "bytes "
+      <> int.to_string(start)
+      <> "-"
+      <> int.to_string(end)
+      <> "/"
+      <> int.to_string(file_size),
+    ))
+
+    let assert wisp.FileChunk(path, offset, limit) = response.body
+
+    path
+    |> should.equal("./test/fixture.txt")
+    offset |> should.equal(start)
+
+    case limit {
+      option.None -> {
+        end |> should.equal(file_size - 1)
+
+        headers
+        |> dict.get("content-length")
+        |> should.equal(Ok(int.to_string(file_size - start)))
+      }
+      option.Some(l) -> {
+        l |> should.equal(end - start + 1)
+
+        headers
+        |> dict.get("content-length")
+        |> should.equal(Ok(int.to_string(l)))
+      }
+    }
+  }
+
+  let assert Ok(file_info) = simplifile.file_info("test/fixture.txt")
+
+  testing.get("/stuff/fixture.txt", [])
+  |> testing.set_header("range", "bytes=0-")
+  |> handler
+  |> validate_content_range(0, file_info.size - 1, file_info)
+
+  testing.get("/stuff/fixture.txt", [])
+  |> testing.set_header("range", "bytes=2-10")
+  |> handler
+  |> validate_content_range(2, 10, file_info)
+
+  testing.get("/stuff/fixture.txt", [])
+  |> testing.set_header("range", "bytes=-4")
+  |> handler
+  |> validate_content_range(file_info.size - 4, file_info.size - 1, file_info)
 }
 
 pub fn temporary_file_test() {


### PR DESCRIPTION
Here's a first pass on supporting the `range` request header through `serve_static`.

A successful response will be a `206 Partial Content`, including setting the `accept-ranges`, `content-range`, and `content-length` response headers.
On a `range` that is out of bounds, it will respond with a `416 Range Not Satisfiable`, and a `400 Bad Request` if the `range` header is malformed.

I needed(?) to add an additional `wisp.Body` variant `FileChunk` that takes an offset and limit to be able to utilize `send_file`. I doubt the `FileChunk` variant will be used for much else so if it's possible to somehow hide this, I'd gladly do it!