### PR TITLE
Update Wisp example documentation after collapse

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,8 @@ pub fn handle_request(request: Request) -> Response {
 
 # Learning Wisp
 
-The Wisp examples are a good place to start. They cover various scenarios and
-include comments and tests.
-
-- [Hello, World!](https://github.com/gleam-wisp/wisp/tree/main/examples/src/hello_world)
-- [Routing](https://github.com/gleam-wisp/wisp/tree/main/examples/src/routing)
-- [Working with form data](https://github.com/gleam-wisp/wisp/tree/main/examples/src/working_with_form_data)
-- [Working with JSON](https://github.com/gleam-wisp/wisp/tree/main/examples/src/working_with_json)
-- [Working with other formats](https://github.com/gleam-wisp/wisp/tree/main/examples/src/working_with_other_formats)
-- [Using a database](https://github.com/gleam-wisp/wisp/tree/main/examples/src/using_a_database)
-- [Serving static assets](https://github.com/gleam-wisp/wisp/tree/main/examples/src/serving_static_assets)
-- [Logging](https://github.com/gleam-wisp/wisp/tree/main/examples/src/logging)
-- [Working with cookies](https://github.com/gleam-wisp/wisp/tree/main/examples/src/working_with_cookies)
-- [Configuring default responses](https://github.com/gleam-wisp/wisp/tree/main/examples/src/configuring_default_responses)
-- [Working with files](https://github.com/gleam-wisp/wisp/tree/main/examples/src/working_with_files)
+The [Wisp examples](./examples/) are a good place to start. They cover various
+scenarios and include comments and tests.
 
 API documentation is available on [HexDocs](https://hexdocs.pm/wisp/).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,38 @@
+# Wisp Examples
+
+For each example, you have its respective [module name](https://tour.gleam.run/basics/modules/).
+You can find the source associated to the example under `./src/$MODULE_NAME`,
+and its tests under `./test/$MODULE_NAME`.
+
+To run an example, you can run the following:
+
+```sh
+# replace $MODULE_NAME with the name of the module associated to each example
+gleam run -m $MODULE_NAME/app
+```
+
+To run the tests, do the following:
+
+```sh
+gleam test
+```
+
+If you would like to use these tests in your project, make sure to change the
+`app` keyword to the name of your project.
+
+## Examples
+
+Here is a list of all the examples and their associated module name (formatted
+"`$MODULE_NAME` - Example title"):
+
+- [`hello_world` - Hello, World!](./src/hello_world)
+- [`routing` - Routing](./src/routing)
+- [`working_with_form_data` - Working with form data](./src/working_with_form_data)
+- [`working_with_json` - Working with JSON](./src/working_with_json)
+- [`working_with_other_formats` - Working with other formats](./src/working_with_other_formats)
+- [`using_a_database` - Using a database](./src/using_a_database)
+- [`serving_static_assets` - Serving static assets](./src/serving_static_assets)
+- [`logging` - Logging](./src/logging)
+- [`working_with_cookies` - Working with cookies](./src/working_with_cookies)
+- [`configuring_default_responses` - Configuring default responses](./src/configuring_default_responses)
+- [`working_with_files` - Working with files](./src/working_with_files)

--- a/examples/src/configuring_default_responses/README.md
+++ b/examples/src/configuring_default_responses/README.md
@@ -1,8 +1,7 @@
 # Wisp Example: Configuring default responses
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m configuring_default_responses/app  # Run the server
 ```
 
 Wisp has a response body value called `Empty`, which is just that: an empty
@@ -15,7 +14,7 @@ You likely want your application to return a generic error page rather than an e
 This example is based off of the ["routing" example][routing] so read that first.
 The additions are detailed here and commented in the code.
 
-[routing]: https://github.com/lpil/wisp/tree/main/examples/src/routing
+[routing]: [examples/src/hello_world](./../routing/)
 
 ### `app/router` module
 
@@ -27,7 +26,7 @@ The `handle_request` function has been updated to return responses with the
 The `middleware` function has been updated to return default responses when an
 `wisp.Empty` response body is returned.
 
-### `app_test` module
+### Unit tests [examples/test/configuring_default_responses/](../../test/configuring_default_responses/)
 
 Tests have been added to test each of the .
 

--- a/examples/src/hello_world/README.md
+++ b/examples/src/hello_world/README.md
@@ -1,8 +1,7 @@
 # Wisp Example: Hello, world!
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m hello_world  # Run the server
 ```
 
 This example shows a minimal Wisp application, it does nothing but respond with
@@ -34,6 +33,6 @@ middleware, and other functions that are used by the request handlers.
 This module contains the application's request handlers. Or "handler" in this
 case, as there's only one!
 
-### `app_test` module
+### Unit tests [examples/test/hello_world/](../../test/hello_world/)
 
 The tests for the application.

--- a/examples/src/logging/README.md
+++ b/examples/src/logging/README.md
@@ -1,8 +1,7 @@
 # Wisp Example: Logging
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m logging/app  # Run the server
 ```
 
 This example shows how to log messages using the BEAM logger.
@@ -10,7 +9,7 @@ This example shows how to log messages using the BEAM logger.
 This example is based off of the ["routing" example][routing], so read that
 one first. The additions are detailed here and commented in the code.
 
-[routing]: https://github.com/lpil/wisp/tree/main/examples/src/routing
+[routing]: [examples/src/hello_world](./../routing/)
 
 ### `app/router` module
 

--- a/examples/src/routing/README.md
+++ b/examples/src/routing/README.md
@@ -1,8 +1,7 @@
 # Wisp Example: Routing
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m routing/app  # Run the server
 ```
 
 This example shows how to route requests to different handlers based on the
@@ -11,14 +10,14 @@ request path and method.
 This example is based off of the ["Hello, World!" example][hello], so read that
 one first. The additions are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/src/hello_world
+[hello]: [examples/src/hello_world](./../hello_world/)
 
 ### `app/router` module
 
 The `handle_request` function now pattern matches on the request and calls other
 request handler functions depending on where the request should go.
 
-### `app_test` module
+### Unit tests [examples/test/routing/](../../test/routing/)
 
 Tests have been added for each of the routes. The `wisp/testing` module is used
 to create different requests to test the application with.

--- a/examples/src/serving_static_assets/README.md
+++ b/examples/src/serving_static_assets/README.md
@@ -1,8 +1,7 @@
 # Wisp Example: Serving static assets
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m serving_static_assets/app  # Run the server
 ```
 
 This example shows how to serve static assets. In this case we'll serve
@@ -12,9 +11,9 @@ of the HTML page, but the same techniques can also be used for other file types.
 This example is based off of the ["Hello, World!" example][hello], so read that
 one first. The additions are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/src/routing
+[hello]: [examples/src/hello_world](./../hello_world/)
 
-### `priv/static` directory
+### [`priv/static`](../../priv/static/) directory
 
 This directory contains the static assets that will be served by the application.
 
@@ -35,7 +34,7 @@ directory and constructs a `Context` record to pass to the handler function.
 
 The `handle_request` function now returns a page of HTML.
 
-### `app_test` module
+### Unit tests [examples/test/serving_static_assets/](../../test/serving_static_assets/)
 
 Tests have been added to ensure that the static assets are served correctly.
 

--- a/examples/src/using_a_database/README.md
+++ b/examples/src/using_a_database/README.md
@@ -1,8 +1,7 @@
 # Wisp Example: Using a database
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m using_a_database/app  # Run the server
 ```
 
 This example shows how to use a database, using a `Context` type to hold the
@@ -11,9 +10,9 @@ database connection.
 This example is based off of the ["working with JSON" example][json], so read
 that first. The additions are detailed here and commented in the code.
 
-[json]: https://github.com/lpil/wisp/tree/main/examples/src/working_with_json
+[json]: [examples/src/working_with_json](./../working_with_json/)
 
-### `gleam.toml` file
+### [`gleam.toml`](../../gleam.toml) file
 
 The `tiny_database` package has been added as a dependency. In a real project
 you would like use a proper database such as Postgres or SQLite.
@@ -37,7 +36,7 @@ the new `app/web/people` module.
 This module has been created to hold all the functions for working with the
 "people" feature, including their request handlers.
 
-### `app_test` module
+### Unit tests [examples/test/using_a_database/](../../test/using_a_database/)
 
 The `with_context` function has been added to create a `Context` record with a
 database connection, and to setup the database.

--- a/examples/src/working_with_cookies/README.md
+++ b/examples/src/working_with_cookies/README.md
@@ -1,14 +1,13 @@
 # Wisp Example: Working with cookies
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m working_with_form_data/app  # Run the server
 ```
 
 This example shows how to read and write cookies, and how to sign cookies so
 they cannot be tampered with.
 
-This example is based off of the ["working with form data" example][form-data] so read that one
+This example is based off of the ["working with form data" example][form_data] so read that one
 first. The additions are detailed here and commented in the code.
 
 Signing of cookies uses the `secret_key_base` value. If this value changes then
@@ -17,13 +16,13 @@ someone gains access to the secret key they will be able to forge cookies. This
 example application generates a random string in `app.gleam`, but in a real
 application you will need to read this secret value from somewhere secure.
 
-[form_data]: https://github.com/lpil/wisp/tree/main/examples/src/working_with_form_data
+[form_data]: [examples/src/working_with_form_data](./../working_with_form_data/)
 
 ### `app/router` module
 
 The `handle_request` function has been updated to read and write cookies.
 
-### `app_test` module
+### Unit tests [examples/test/working_with_cookies/](../../test/working_with_cookies/)
 
 Tests have been added to test that cookies are handled correctly, and to create signed cookies for test requests.
 

--- a/examples/src/working_with_files/README.md
+++ b/examples/src/working_with_files/README.md
@@ -1,22 +1,21 @@
 # Wisp Example: Working with files
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m working_with_files/app  # Run the server
 ```
 
 This example shows how to accept file uploads and allow users to download files.
 
-This example is based off of the ["working with form data" example][formdata],
+This example is based off of the ["working with form data" example][form_data],
 so read that first. The additions are detailed here and commented in the code.
 
-[formdata]: https://github.com/lpil/wisp/tree/main/examples/src/working_with_form_data
+[form_data]: [examples/src/working_with_form_data](./../working_with_form_data/)
 
 ### `app/router` module
 
 The `handle_request` function has been updated to upload and download files.
 
-### `app_test` module
+### Unit tests [examples/test/working_with_files/](../../test/working_with_files/)
 
 Tests have been added that upload and download files to verify the behaviour.
 

--- a/examples/src/working_with_form_data/README.md
+++ b/examples/src/working_with_form_data/README.md
@@ -1,8 +1,7 @@
 # Wisp Example: Working with form data
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m working_with_form_data/app  # Run the server
 ```
 
 This example shows how to read urlencoded and multipart formdata from a request
@@ -11,15 +10,15 @@ This example is based off of the ["Hello, World!" example][hello], and uses
 concepts from the [routing example][routing] so read those first. The additions
 are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/src/hello_world
-[routing]: https://github.com/lpil/wisp/tree/main/examples/src/routing
+[hello]: [examples/src/hello_world](./../hello_world/)
+[routing]: [examples/src/hello_world](./../routing/)
 
 ### `app/router` module
 
 The `handle_request` function has been updated to read the form data from the
 request body and make use of values from it.
 
-### `app_test` module
+### Unit tests [examples/test/working_with_form_data/](../../test/working_with_form_data/)
 
 Tests have been added that send requests with form data bodies and check that
 the expected response is returned.

--- a/examples/src/working_with_json/README.md
+++ b/examples/src/working_with_json/README.md
@@ -1,8 +1,7 @@
 # Wisp Example: Working with JSON
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m working_with_json/app  # Run the server
 ```
 
 This example shows how to read JSON from a request and return JSON in the
@@ -12,10 +11,10 @@ This example is based off of the ["Hello, World!" example][hello], and uses
 concepts from the [routing example][routing] so read those first. The additions
 are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/src/hello_world
-[routing]: https://github.com/lpil/wisp/tree/main/examples/src/routing
+[hello]: [examples/src/hello_world](./../hello_world/)
+[routing]: [examples/src/hello_world](./../routing/)
 
-### `gleam.toml` file
+### [`gleam.toml`](../../gleam.toml) file
 
 The `gleam_json` JSON package has been added as a dependency.
 
@@ -25,7 +24,7 @@ The `handle_request` function has been updated to read JSON from the
 request body, decode it using the Gleam standard library, and return JSON
 back to the client.
 
-### `app_test` module
+### Unit tests [examples/test/working_with_json/](../../test/working_with_json/)
 
 Tests have been added that send requests with JSON bodies and check that the
 expected response is returned.

--- a/examples/src/working_with_other_formats/README.md
+++ b/examples/src/working_with_other_formats/README.md
@@ -1,10 +1,8 @@
 # Wisp Example: Working with other formats
 
 ```sh
-gleam run   # Run the server
-gleam test  # Run the tests
+gleam run -m working_with_other_formats/app  # Run the server
 ```
-
 This example shows how to read and return formats that do not have special
 support in Wisp. In this case we'll use CSV, but the same techniques can be used
 for any format.
@@ -13,10 +11,10 @@ This example is based off of the ["Hello, World!" example][hello], and uses
 concepts from the [routing example][routing] so read those first. The additions
 are detailed here and commented in the code.
 
-[hello]: https://github.com/lpil/wisp/tree/main/examples/src/hello_world
-[routing]: https://github.com/lpil/wisp/tree/main/examples/src/routing
+[hello]: [examples/src/hello_world](./../hello_world/)
+[routing]: [examples/src/hello_world](./../routing/)
 
-### `gleam.toml` file
+### [`gleam.toml`](../../gleam.toml) file
 
 The `gsv` CSV package has been added as a dependency.
 
@@ -26,7 +24,7 @@ The `handle_request` function has been updated to read a string from the
 request body, decode it using the `gsv` library, and return some CSV data
 back to the client.
 
-### `app_test` module
+### Unit tests [examples/test/working_with_other_formats/](../../test/working_with_other_formats/)
 
 Tests have been added that send requests with CSV bodies and check that the
 expected response is returned.


### PR DESCRIPTION
After collapse of the examples, the documentation no longer reflects the correct commands for running the examples.

Updated documentation to describe how they can be run, and fixed some references that were pointing to a fork.

Added relative links directly to tests.