### PR TITLE
Fix broken examples link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ pub fn handle_request(request: Request) -> Response {
 
 # Learning Wisp
 
-The [Wisp examples](./examples/) are a good place to start. They cover various
-scenarios and include comments and tests.
+The [Wisp examples](https://github.com/gleam-wisp/wisp/tree/main/examples)
+are a good place to start. They cover various scenarios and include comments and
+tests.
 
 API documentation is available on [HexDocs](https://hexdocs.pm/wisp/).
 


### PR DESCRIPTION
When browsing the docs from Hex, clicking on the examples link would send to a 404 page instead of the examples!