### PR TITLE
Added /app to run command in the hello_world example README, to match the other examples. 

### DIFF
--- a/examples/src/hello_world/README.md
+++ b/examples/src/hello_world/README.md
@@ -1,7 +1,7 @@
 # Wisp Example: Hello, world!
 
 ```sh
-gleam run -m hello_world  # Run the server
+gleam run -m hello_world/app  # Run the server
 ```
 
 This example shows a minimal Wisp application, it does nothing but respond with


### PR DESCRIPTION
Hello! 
When viewing the hello_world example, running the command in the README gives the following output:
wisp/examples/src/hello_world$ gleam run -m hello_world
   Compiled in 0.03s
error: Module does not exist

Module `hello_world` was not found.
Hint: Try creating the file `src/hello_world.gleam`.

But if you add /app to the command, it runs as expected:
wisp/examples/src/hello_world$ gleam run -m hello_world/app
   Compiled in 0.03s
    Running hello_world/app.main
Listening on http://127.0.0.1:8000

I changed the README to include the '/app'. I was going to add it to the other examples as well, but all the rest already include /app.

Thanks!