### PR TITLE
Change doc to reflect changes of v1.5.0

### DIFF
--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -1618,9 +1618,8 @@ fn handle_etag(
 }
 
 /// A middleware function that converts `HEAD` requests to `GET` requests,
-/// handles the request, and then discards the response body. This is useful so
-/// that your application can handle `HEAD` requests without having to implement
-/// handlers for them.
+/// handles the request. This is useful so that your application can handle
+/// `HEAD` requests without having to implement handlers for them.
 ///
 /// The `x-original-method` header is set to `"HEAD"` for requests that were
 /// originally `HEAD` requests.


### PR DESCRIPTION
The docs of the handle_head function did not reflect the changes that were done in v1.5.0.

It does not remove the body of the response anymore, because it relies on the underlying web server to do that based on the `x-original-method` header.