### PR TITLE
Fix static_file_handler handler range limit check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed a bug in the `static_file_handler` where valid requests were rejected
+  because the `range.limit` was incorrectly treated as the end of the range.
 - The Mist web server related module has been moved to the `wisp_mist` adapter
   package. A `wisp_ewe` package has been created too!
 - `send_file` failing will now result in an internal server error being sent.

--- a/src/wisp.gleam
+++ b/src/wisp.gleam
@@ -1010,7 +1010,10 @@ pub fn require_content_type(
 /// If the body cannot be parsed successfully then a response with status
 /// code 400: Bad request will be returned to the client.
 ///
-pub fn require_json(request: Request, next: fn(Dynamic) -> Response) -> Response {
+pub fn require_json(
+  request: Request,
+  next: fn(Dynamic) -> Response,
+) -> Response {
   use <- require_content_type(request, "application/json")
   use body <- require_string_body(request)
   case json.parse(body, decode.dynamic) {
@@ -1546,15 +1549,16 @@ fn handle_file_range_header(
       False -> range
     }
 
-    let end_is_invalid =
+    let limit_is_invalid =
       range.limit
-      |> option.map(fn(end) {
-        end < 0 || end >= file_info.size || end < range.offset
+      |> option.map(fn(limit) {
+        let end = range.offset + limit - 1
+        limit < 0 || end >= file_info.size
       })
       |> option.unwrap(False)
 
     use <- bool.guard(
-      range.offset < 0 || range.offset >= file_info.size || end_is_invalid,
+      range.offset < 0 || range.offset >= file_info.size || limit_is_invalid,
       Error(
         response(416)
         |> response.prepend_header("range", "bytes=*"),

--- a/test/wisp_test.gleam
+++ b/test/wisp_test.gleam
@@ -618,6 +618,15 @@ pub fn serve_static_range_start_limit_test() {
   assert simulate.read_body(response) == "llo, Joe! 👨"
 }
 
+pub fn serve_static_range_short_at_high_offset_test() {
+  let response =
+    simulate.request(http.Get, "/fixture.txt")
+    |> simulate.header("range", "bytes=8-9")
+    |> static_file_handler
+
+  assert simulate.read_body(response) == "oe"
+}
+
 pub fn serve_static_range_negative_test() {
   let response =
     simulate.request(http.Get, "/fixture.txt")


### PR DESCRIPTION
Fixed a bug in the `static_file_handler` where valid requests were rejected because the `range.limit` was incorrectly treated as the end of the range.